### PR TITLE
Add automatic mappability file creation for suncity

### DIFF
--- a/.idea/jetstream_resources.iml
+++ b/.idea/jetstream_resources.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/jetstream_resources.iml
+++ b/.idea/jetstream_resources.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/suncity/create_mappability_file.sh
+++ b/suncity/create_mappability_file.sh
@@ -17,7 +17,7 @@ fi
 
 ## Get executables in PATH
 module load ${GATK_MODULE}
-TOPLEVEL_DIR=~/
+
 ### make target directories:
 if [[ -d ${TOPLEVEL_DIR} && -w ${TOPLEVEL_DIR} ]] ;
 then

--- a/suncity/create_mappability_file.sh
+++ b/suncity/create_mappability_file.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Usage generic : $0 <resources.ini>
-# Usage example suncity: $0 <suncity_resources.ini>
+# Usage : $0 <resources.ini>
+
 
 # Check to resources.ini was provided on the command line
 if [ -n "$1" ]
@@ -15,24 +15,58 @@ fi
 # Read required variables from configuration file
 . ${1}
 
-## Get executables in PATH
-module load ${GATK_MODULE}
+## Check if executables in PATH
+if [[ $(type -P "gatk") ]]
+then
+  echo "SUCCESS: gatk found in PATH" ;
+else
+  echo "ERROR: gatk NOT in PATH; Need gatk installed; At least version 4.1.4.0" ;
+  exit 2
+fi
 
 ### make target directories:
 if [[ -d ${TOPLEVEL_DIR} && -w ${TOPLEVEL_DIR} ]] ;
 then
-  mkdir -p ${TOPLEVEL_DIR}/public_databases/bismap/ && cd ${TOPLEVEL_DIR}/public_databases/bismap/ || ( echo -e "ERROR entering directory: ${TOPLEVEL_DIR}/public_databases/bismap/" && exit 1 )
+  mkdir -p ${TOPLEVEL_DIR}/public_databases/bismap/
+  cd ${TOPLEVEL_DIR}/public_databases/bismap/
+  if [[ $? -ne 0 ]]
+  then
+    echo -e "ERROR entering directory: ${TOPLEVEL_DIR}/public_databases/bismap/"
+    exit 1
+  fi
 else
   echo -e "ERROR: DIR NOT FOUND << ${TOPLEVEL_DIR}>>; This directory MUST be created before running this script << $0 >>";
   exit 1
 fi
 
-echo -e ${PWD}
+echo -e "curdir: ${PWD}"
+
+# Initialize a samtools_stats index README
+touch README
+echo >> README
+echo "For details on file creation see the associated github repository:" >> README
+echo "https://github.com/tgen/jetstream_resources/suncity" >> README
+echo "and ">> README
+echo "https://bismap.hoffmanlab.org/" >> README
+echo >> README
+echo "Created and downloaded by ${CREATOR}" >> README
+date >> README
+echo >> README
+echo "$0 <resources.ini>  --> Usage details:" >> README
+echo "The input is an ini file with specific defined variables; Example of ini file can be found in the pipeline folders; such as << suncity_resources.ini >>" >> README
+echo >> README
+echo "Why these files?" >> README
+echo "Mappability Files are used with GATK CNV tool to get better accuracy in copy number calls." > README
+echo >> README
+echo >> README
+
+
 
 ## check if file already exist in TARGET directory
 if [[ -e k100.umap.bed.gz ]]
 then
-  rm k100.umap.bed.gz &>/dev/null
+  echo -e "File << k100.umap.bed.gz >> already exists. Exiting to prevent overwriting it."
+  exit 2
 fi
 
 ## Downloading compressed BED file
@@ -53,3 +87,4 @@ else
   echo -e "ERROR: Download Issue;\nMappability Files Creation: FAILED"
   exit 1
 fi
+

--- a/suncity/create_mappability_file.sh
+++ b/suncity/create_mappability_file.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Usage generic : $0 <resources.ini>
+# Usage example suncity: $0 <suncity_resources.ini>
+
+# Check to resources.ini was provided on the command line
+if [ -n "$1" ]
+then
+  echo "Required ini file detected"
+else
+  echo "Input INI file not provided, exiting due to missing requirement"
+  exit 1
+fi
+
+# Read required variables from configuration file
+. ${1}
+
+## Get executables in PATH
+module load ${GATK_MODULE}
+TOPLEVEL_DIR=~/
+### make target directories:
+if [[ -d ${TOPLEVEL_DIR} && -w ${TOPLEVEL_DIR} ]] ;
+then
+  mkdir -p ${TOPLEVEL_DIR}/public_databases/bismap/ && cd ${TOPLEVEL_DIR}/public_databases/bismap/ || ( echo -e "ERROR entering directory: ${TOPLEVEL_DIR}/public_databases/bismap/" && exit 1 )
+else
+  echo -e "ERROR: DIR NOT FOUND << ${TOPLEVEL_DIR}>>; This directory MUST be created before running this script << $0 >>";
+  exit 1
+fi
+
+echo -e ${PWD}
+
+## check if file already exist in TARGET directory
+if [[ -e k100.umap.bed.gz ]]
+then
+  rm k100.umap.bed.gz &>/dev/null
+fi
+
+## Downloading compressed BED file
+wget ${BISMAP_UMPA_DOWNLOAD_LINK}
+
+if [[ $? -eq 0 ]]
+then
+  zcat k100.umap.bed.gz | awk 'NR >1' > k100.umap.no_header.bed
+  gatk IndexFeatureFile --feature-file k100.umap.no_header.bed
+  if [[ $? -eq 0 ]]
+  then
+      echo -e "Mappability Files Creation Completed SUCCESSFULLY"
+  else
+    echo -e "ERROR: GATK issue;\nMappability Files Creation: FAILED"
+    exit 1
+  fi
+else
+  echo -e "ERROR: Download Issue;\nMappability Files Creation: FAILED"
+  exit 1
+fi

--- a/suncity/create_mappability_file.sh
+++ b/suncity/create_mappability_file.sh
@@ -15,15 +15,6 @@ fi
 # Read required variables from configuration file
 . ${1}
 
-## Check if executables in PATH
-if [[ $(type -P "gatk") ]]
-then
-  echo "SUCCESS: gatk found in PATH" ;
-else
-  echo "ERROR: gatk NOT in PATH; Need gatk installed; At least version 4.1.4.0" ;
-  exit 2
-fi
-
 ### make target directories:
 if [[ -d ${TOPLEVEL_DIR} && -w ${TOPLEVEL_DIR} ]] ;
 then
@@ -41,9 +32,25 @@ fi
 
 echo -e "curdir: ${PWD}"
 
+## Check if executables in PATH
+if [[ $ENVIRONMENT == "TGen" ]]
+then
+  # Load the expected GATK module
+  echo "loading GATK module ${GATK_MODULE} ..."
+  module load ${GATK_MODULE}
+elif [[ $ENVIRONMENT == "LOCAL" ]]
+then
+  if [[ $(type -P "gatk") ]]
+  then
+    echo "gatk found" ;
+  else
+    echo "ERROR: gatk NOT in PATH; Need  'gatk'  installed to run script $0; Install GATK version 4.1.4.0 or up" ;
+    exit 2
+  fi
+fi
+
 # Initialize a samtools_stats index README
-touch README
-echo >> README
+echo > README
 echo "For details on file creation see the associated github repository:" >> README
 echo "https://github.com/tgen/jetstream_resources/suncity" >> README
 echo "and ">> README
@@ -56,7 +63,7 @@ echo "$0 <resources.ini>  --> Usage details:" >> README
 echo "The input is an ini file with specific defined variables; Example of ini file can be found in the pipeline folders; such as << suncity_resources.ini >>" >> README
 echo >> README
 echo "Why these files?" >> README
-echo "Mappability Files are used with GATK CNV tool to get better accuracy in copy number calls." > README
+echo "Mappability Files are used with GATK CNV tool to get better accuracy in copy number calls." >> README
 echo >> README
 echo >> README
 
@@ -65,11 +72,12 @@ echo >> README
 ## check if file already exist in TARGET directory
 if [[ -e k100.umap.bed.gz ]]
 then
-  echo -e "File << k100.umap.bed.gz >> already exists. Exiting to prevent overwriting it."
+  echo -e "File << k100.umap.bed.gz >> already exists. Exiting to prevent overwriting it. (see in directory: ${PWD})"
   exit 2
 fi
 
 ## Downloading compressed BED file
+echo "getting file of interest using wget ..."
 wget ${BISMAP_UMPA_DOWNLOAD_LINK}
 
 if [[ $? -eq 0 ]]

--- a/suncity/suncity_resources.ini
+++ b/suncity/suncity_resources.ini
@@ -1,5 +1,40 @@
 # Variables used to define Phoenix Resource Locations
 # Used by Build scripts to create needed files in expected locations
+###########################################
+## UPDATE THESE BASED ON YOUR LOCAL ENVIRONMENT
+###########################################
+
+# Set your environment variable (MUST BE ONE OF "TGen" or "LOCAL"
+ENVIRONMENT=TGen
+#ENVIRONMENT=LOCAL
+
+# Define input and output directories
+PATH_TO_REPO=/home/tgenjetstream/git_repositories/jetstream_resources
+PARENT_DIR=/home/tgenref/homo_sapiens/grch37_hg19
+TOPLEVEL_DIR=/home/tgenref/homo_sapiens/grch37_hg19/hs37d5_suncity
+CREATOR=jkeats
+
+# To automate COSMIC download we use their token download but you must have a valid account (https://cancer.sanger.ac.uk/cosmic/login)
+# The associated script will ask for your password during execution
+COSMIC_ACCOUNT_EMAIL=jkeats@tgen.org
+
+## WARNING!!!
+## PLEASE UPDATE THESE VARIABLES TO SUPPORT LOCAL BUILD
+
+# Set the number of local compute cores to leverage threading options for some steps
+LOCAL_COMPUTE_CORES=20
+# snpEff.jar (https://sourceforge.net/projects/snpeff/files/snpEff_v4_3t_core.zip/download)
+SNPEFF=/packages/snpEff/snpEff_v4_3t_core/snpEff/snpEff.jar
+# NCBI eUTILs PATH (https://www.ncbi.nlm.nih.gov/books/NBK179288/)
+EUTILS_PATH=/home/jkeats/downloads/edirect/
+# JSON.awk (https://github.com/step-/JSON.awk/archive/1.3.tar.gz)
+JSON_AWK=/home/jkeats/downloads/JSON.awk-1.3/JSON.awk
+# UCSC gtfToGenePred binary (http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/gtfToGenePred)
+GTFTOGENEPRED_BINARY=/home/tgenref/binaries/gtfToGenePred/gtfToGenePred
+# faToTwoBit (rsync -aP rsync://hgdownload.soe.ucsc.edu/genome/admin/exe/linux.x86_64/faToTwoBit .)
+FATOTWOBIT=/home/tgenref/binaries/faToTwoBit/faToTwoBit
+
+
 
 ###########################################
 ##  Common Variables
@@ -7,10 +42,6 @@
 
 WORKFLOW_NAME=suncity
 SPECIES="Homo sapiens"
-PATH_TO_REPO=/home/tgenjetstream/git_repositories/jetstream_resources
-CREATOR=jkeats
-PARENT_DIR=/home/tgenref/homo_sapiens/grch37_hg19
-TOPLEVEL_DIR=/home/tgenref/homo_sapiens/grch37_hg19/hs37d5_suncity
 
 ###########################################
 ##  Required Modules (Or available in your $PATH

--- a/suncity/suncity_resources.ini
+++ b/suncity/suncity_resources.ini
@@ -139,3 +139,11 @@ BROAD_BUNDLE_1000G_DOWNLOAD_LINK=ftp://gsapubftp-anonymous@ftp.broadinstitute.or
 BROAD_BUNDLE_1000G_DOWNLOAD_MD5SUM_LINK=ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/b37/1000G_phase1.indels.b37.vcf.gz.md5
 
 BROAD_BUNDLE_1000Gphase3_DOWNLOAD_LINK=ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/b37/1000G_phase3_v4_20130502.sites.vcf.gz
+
+
+###########################################
+## Mappability Files - BISMAP - UMAP
+###########################################
+BISMAP_UMPA_DOWNLOAD_LINK=https://bismap.hoffmanlab.org/raw/hg19/k100.umap.bed.gz
+
+


### PR DESCRIPTION
I have added a script **create_mappability_file.sh** to automatically capture GRCh37-single-read Umap K100 mappability file for GATK CNV.
I also updated the suncity_resources.ini by adding a variable pointing to the expected compressed bed file.