### PR TITLE
collect study timing updates

### DIFF
--- a/reporting_tools/report_cpu_usage.py
+++ b/reporting_tools/report_cpu_usage.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
-###
-# Copied from Ryan Richholt Toolkit
-###
-
-# Usage: report_cpu_usage.py <Path_to_Jetstream_Project>
+# Usage: report_cpu_usage.py --project <Path_to_Jetstream_Project> --ignore_tags <tag_to_ignore> <another_tag_to_ignore>
+# Arguments are optional 
 
 # Generates a report of CPU Usage from a Jetstream project
-# Future improvements : leverage tags for subsummary by subtype, RG_SM, Individual Tools
+
+# Author: Ryan Richolt
+# Updated by: Bryce Turner - bturner@tgen.org
 
 import argparse
 import logging
@@ -23,7 +22,8 @@ ELAPSED_PAT = re.compile(r'((?P<days>\d*)-)?(?P<hours>\d*):(?P<minutes>\d*):(?P<
 
 def arg_parser():
     parser = argparse.ArgumentParser(description='Report CPU hours for a project')
-    parser.add_argument('project', nargs='*')
+    parser.add_argument('--project', nargs='*')
+    parser.add_argument('--ignore_tags', nargs='+')
     return parser
 
 
@@ -40,30 +40,43 @@ def summarize_task_cpuhs(t):
     return cpus, fElapsed, cpuh
 
 
-def report(project):
+def report(project, ignore_tags):
     total_cpu_hours = 0
 
-    print('CPUs\tElapsed\tHours\tCumulative\tTask')
+    print('CPUs\tElapsed\tHours\tCumulative\tTask\tTags')
     workflow = project.load_workflow()
     log.critical(f'Reporting on: {workflow}')
-    for name, t in project.load_workflow().tasks.items():
+    for name, t in workflow.tasks.items():
         cpus, task_elapsed, task_cpu_hours = summarize_task_cpuhs(t)
         total_cpu_hours += task_cpu_hours
-        print(f'{cpus}\t{task_elapsed}\t{round(task_cpu_hours, 2)}\t{round(total_cpu_hours, 2)}\t{t}')
+        tags = t.directives.get('tags', ['Untagged'])
+        ignore_tags_re_string = '|'.join(f'({tag})' for tag in ignore_tags).replace("-", "_")
+        cleanre = re.compile(ignore_tags_re_string)
+        # We perform a regex search because we expect the ignore tags to be partial
+        # for example may want to ignore 'stats' tags, 'stats' may not be an actual tag
+        # but it could be part of a tag, e.g. stats2json or stats2lims
+        clean_tags = [tag for tag in tags if not re.search(cleanre, tag.replace("-", "_")) ]
+        tags_string = '_'.join(clean_tags).replace(" ", "_")
+        print(f'{cpus}\t{task_elapsed}\t{round(task_cpu_hours, 2)}\t{round(total_cpu_hours, 2)}\t{name}\t{tags_string}')
 
 
 def main():
     parser = arg_parser()
     args = parser.parse_args()
 
+    if args.ignore_tags:
+        ignore_tags = args.ignore_tags
+    else:
+        ignore_tags = []
+
     if args.project:
         for p in args.project:
             try:
-                report(jetstream.Project(path=p))
+                report(jetstream.Project(path=p), ignore_tags)
             except Exception as e:
                 log.exception(f'Failed to generate report for "{p}"')
     else:
-        report(jetstream.Project())
+        report(jetstream.Project(), ignore_tags)
 
 
 if __name__ == '__main__':

--- a/reporting_tools/study_summary_Graphs.R
+++ b/reporting_tools/study_summary_Graphs.R
@@ -26,23 +26,23 @@ if (is.null(opt$study_name)){
 tasks <- read_tsv("study_task_summary.txt")
 projects <- read_tsv("study_project_summary.txt")
 
-ggplot(tasks, aes(x=Group, y=Total_CPU_Hours)) + 
-  geom_jitter() + 
+ggplot(tasks, aes(x=Tags, y=Total_CPU_Hours)) + 
+  geom_jitter(size=0.5) + 
   coord_flip()
 ggsave(file=paste(opt$study_name, "_TotalCPUhours_by_Group_per_Project.png", sep=""), dpi=150)
 
-ggplot(tasks, aes(x=Group, y=Total_Elapsed_Hours)) + 
-  geom_jitter() + 
+ggplot(tasks, aes(x=Tags, y=Total_Elapsed_Hours)) + 
+  geom_jitter(size=0.5) + 
   coord_flip()
 ggsave(file=paste(opt$study_name, "_TotalElapsedHours_by_Group_per_Project.png", sep=""), dpi=150)
 
-ggplot(tasks, aes(x=Group, y=Max_Task_Elapsed_Hours)) + 
-  geom_jitter() + 
+ggplot(tasks, aes(x=Tags, y=Max_Task_Elapsed_Hours)) + 
+  geom_jitter(size=0.5) + 
   coord_flip()
 ggsave(file=paste(opt$study_name, "_MaxTaskElapsedHours_by_Group_per_Project.png", sep=""), dpi=150)
 
-ggplot(tasks, aes(x=Group, y=Max_Task_CPU_Hours)) + 
-  geom_jitter() + 
+ggplot(tasks, aes(x=Tags, y=Max_Task_CPU_Hours)) + 
+  geom_jitter(size=0.5) + 
   coord_flip()
 ggsave(file=paste(opt$study_name, "_MaxTaskCPUhours_by_Group_per_Project.png", sep=""), dpi=150)
 

--- a/reporting_tools/summarize_project_runtime.R
+++ b/reporting_tools/summarize_project_runtime.R
@@ -63,103 +63,26 @@ project_name <- opt$project
 
 ## Update the tibble table
 
-# Remove "<Task(complete): " and ">" from the TASK column
-data <- data %>% mutate_if(is.character, str_replace_all, pattern = '<', replacement = "")
-data <- data %>% mutate_if(is.character, str_replace_all, pattern = "[(]", replacement = "")
-data <- data %>% mutate_if(is.character, str_replace_all, pattern = '[)]', replacement = "")
-data <- data %>% mutate_if(is.character, str_replace_all, pattern = 'Taskcomplete: ', replacement = "")
-data <- data %>% mutate_if(is.character, str_replace_all, pattern = '[>]', replacement = "")
-
 # Parse the Elapsed time into hours, minutes, seconds
 data <- data %>% separate(Elapsed, into = c("hours", "minutes", "seconds"), sep = ":", convert = TRUE, remove = FALSE)
 
-# Add Summary Columns
-data <- data %>% mutate(Group = case_when(str_detect(Task, "^copy_fastqs") ~ "Copy_Fastq",
-                                          str_detect(Task, "^split_fastq") ~ "Split_Fastq",
-                                          str_detect(Task, "^chunked_bwa_mem_samtools_fixmate") ~ "BWA_Align",
-                                          str_detect(Task, "^chunked_bwa_mem2_samtools_fixmate") ~ "BWA2_Align",
-                                          str_detect(Task, "^chunked_samtools_merge_rg_bams") ~ "Samtools_Merge",
-                                          str_detect(Task, "^samtools_markdup") ~ "Samtools_MarkDup",
-                                          str_detect(Task, "^bam_to_cram") ~ "Samtools_BamCram",
-                                          str_detect(Task, "^gatk_collectwgsmetrics") ~ "Picard_Metric",
-                                          str_detect(Task, "^gatk_collectwgsmetricswithnonzerocoverage") ~ "Picard_Metric",
-                                          str_detect(Task, "^gatk_collectrawwgsmetrics") ~ "Picard_Metric",
-                                          str_detect(Task, "^gatk_collectmultiplemetrics") ~ "Picard_Metric",
-                                          str_detect(Task, "^gatk_convertsequencingarrtifacttooxog") ~ "Picard_Metric",
-                                          str_detect(Task, "^gatk_collecthsmetrics") ~ "Picard_Metric",
-                                          str_detect(Task, "^gatk_collectrnaseqmetrics") ~ "Picard_Metric",
-                                          str_detect(Task, "^samtools_stats") ~ "Samtools_Metric",
-                                          str_detect(Task, "^samtools_flagstat") ~ "Samtools_Metric",
-                                          str_detect(Task, "^samtools_idxstats") ~ "Samtools_Metric",
-                                          str_detect(Task, "^verifybamid2") ~ "Random_Stat",
-                                          str_detect(Task, "^freebayes_sex_check") ~ "Random_Stat",
-                                          str_detect(Task, "^snpsniffer_geno") ~ "Random_Stat",
-                                          str_detect(Task, "^hmmcopy_make_wig_bwa") ~ "iChor_CNA",
-                                          str_detect(Task, "^ichor_cna_bwa") ~ "iChor_CNA",
-                                          str_detect(Task, "^haplotypecaller_gvcf") ~ "HaplotypeCaller",
-                                          str_detect(Task, "^haplotypecaller_gvcf_merge") ~ "HaplotypeCaller",
-                                          str_detect(Task, "^manta") ~ "Manta_Strelka",
-                                          str_detect(Task, "^strelka2_filter_variants") ~ "Variant_Filter",
-                                          str_detect(Task, "^strelka2") ~ "Manta_Strelka",
-                                          str_detect(Task, "^deepvariant_make_examples") ~ "Deepvariant",
-                                          str_detect(Task, "^deepvariant_call_variants") ~ "Deepvariant",
-                                          str_detect(Task, "^deepvariant_postprocess_variants") ~ "Deepvariant",
-                                          str_detect(Task, "^deepvariant_filter_variants") ~ "Deepvariant",
-                                          str_detect(Task, "^lancet_merge_chunks") ~ "Variant_Merge",
-                                          str_detect(Task, "^lancet_filter_variants") ~ "Variant_Filter",
-                                          str_detect(Task, "^lancet") ~ "Lancet",
-                                          str_detect(Task, "^octopus_merge_chunks") ~ "Variant_Merge",
-                                          str_detect(Task, "^octopus_filter_variants") ~ "Variant_Filter",
-                                          str_detect(Task, "^octopus") ~ "Octopus", 
-                                          str_detect(Task, "^vardict_merge_chunks") ~ "Variant_Merge",
-                                          str_detect(Task, "^vardict_filter_variants") ~ "Variant_Filter",
-                                          str_detect(Task, "^vardict") ~ "VarDictJava",
-                                          str_detect(Task, "^mutect2_merge_chunks") ~ "Variant_Merge",
-                                          str_detect(Task, "^mutect2_filter_variants") ~ "Variant_Filter",
-                                          str_detect(Task, "^mutect2_filter_calls") ~ "Mutect",
-                                          str_detect(Task, "^mutect2_calculate_contamination") ~ "Mutect",
-                                          str_detect(Task, "^mutect2_merge_pileup_summaries") ~ "Mutect",
-                                          str_detect(Task, "^mutect2_learn_readorientationmodel") ~ "Mutect",
-                                          str_detect(Task, "^mutect2_merge_stats") ~ "Mutect",
-                                          str_detect(Task, "^mutect2_merge_pileup_summaries") ~ "Mutect",
-                                          str_detect(Task, "^mutect2_GetPileupSummaries") ~ "Mutect",
-                                          str_detect(Task, "^mutect2") ~ "Mutect",
-                                          str_detect(Task, "^vcfmerger2") ~ "VCFmerger",
-                                          str_detect(Task, "^bcftools_annotate") ~ "Annotation",
-                                          str_detect(Task, "^snpeff") ~ "Annotation",
-                                          str_detect(Task, "^vep") ~ "Annotation",
-                                          str_detect(Task, "^bcftools_annotate") ~ "Annotation",
-                                          str_detect(Task, "^bcftools_annotate") ~ "Annotation",
-                                          str_detect(Task, "^delly") ~ "Delly",
-                                          str_detect(Task, "^gatk_call_cnv") ~ "GATK_CNV",
-                                          str_detect(Task, "^add_matched_rna") ~ "RNA_Steps",
-                                          str_detect(Task, "^add_rna_header_to_vcf") ~ "RNA_Steps",
-                                          str_detect(Task, "^salmon_quant_cdna") ~ "RNA_Steps",
-                                          str_detect(Task, "^star_quant") ~ "RNA_Steps",
-                                          str_detect(Task, "^star_fusion") ~ "RNA_Steps",
-                                          str_detect(Task, "^fixmate_sort_star") ~ "RNA_Steps",
-                                          str_detect(Task, "^markduplicates_star_gatk") ~ "RNA_Steps",
-                                          str_detect(Task, "^rna_getBTcellLociCounts") ~ "RNA_Steps",
-                                          TRUE ~ "Misc"
-                                          )
-                        )
-
+data <- data %>% select("Tags", everything())
 
 # Plot
-ggplot(data, aes(x=Group, y=Elapsed, color=as.factor(CPUs))) +
-  geom_jitter() + 
+ggplot(data, aes(x=Tags, y=Elapsed, color=as.factor(CPUs))) +
+  geom_jitter(size=0.5) + 
   scale_color_discrete() +
   coord_flip()
 ggsave(file=paste(project_name, "_ElapsedTime_by_Task_per_Group.png", sep=""), dpi=150)
 
-ggplot(data, aes(x=Group, y=Hours)) +
-  geom_jitter() + 
+ggplot(data, aes(x=Tags, y=Hours)) +
+  geom_jitter(size=0.5) + 
   coord_flip()
 ggsave(file=paste(project_name, "_CPUhours_by_Task_per_Group.png", sep=""), dpi=150)
 
 # Group and summarize to get realtime and CPU hours by task Group
 task_summary <- data %>% 
-  group_by(Group) %>% 
+  group_by(Tags) %>% 
   summarise(Tasks = n(),
             Total_CPU_Hours = sum(Hours), 
             Max_Task_CPU_Hours = max(Hours),
@@ -171,15 +94,15 @@ task_summary <- data %>%
 
 # Add column with project
 task_summary <- task_summary %>% 
-  add_column(Project = project_name, .before = "Group")
+  add_column(Project = project_name, .before = "Tags")
   
 # Plot Summary Data
-ggplot(task_summary, aes(x=Group, y=Total_Elapsed_Hours)) +
+ggplot(task_summary, aes(x=Tags, y=Total_Elapsed_Hours)) +
   geom_bar(stat="identity") + 
   coord_flip()
 ggsave(file=paste(project_name, "_ElapsedHours_by_TaskGroup.png", sep=""), dpi=150)
 
-ggplot(task_summary, aes(x=Group, y=Total_CPU_Hours)) +
+ggplot(task_summary, aes(x=Tags, y=Total_CPU_Hours)) +
   geom_bar(stat="identity") + 
   coord_flip()
 ggsave(file=paste(project_name, "_CPUhours_by_TaskGroup.png", sep=""), dpi=150)


### PR DESCRIPTION
Freezing these changes into a release window so that we can cleanup existing branches. 

Overall this adds a change for how we run report_cpu_usage.py, since this script requires jetstream, but it's possible a user will load a different version of python and then reporting will fail with a potentially confusing message. More noticeably we singularity exec R now and have more dynamically generated plots based of task tags. 